### PR TITLE
Increase visibility of getFormatter() and add getFormatterClass() to easily find supported country.

### DIFF
--- a/src/PostcodeFormatter.php
+++ b/src/PostcodeFormatter.php
@@ -52,6 +52,15 @@ class PostcodeFormatter
 
     /**
      * @param string $country
+     * @return bool
+     */
+    public function isSupportedCountry(string $country): bool
+    {
+        return class_exists($this->getFormatterClass($country));
+    }
+
+    /**
+     * @param string $country
      *
      * @return CountryPostcodeFormatter
      *
@@ -67,14 +76,22 @@ class PostcodeFormatter
             throw new UnknownCountryException('Unknown country: ' . $country);
         }
 
-        $country = strtoupper($country);
-
-        $class = __NAMESPACE__ . '\\Formatter\\' . $country . 'Formatter';
+        $class = $this->getFormatterClass($country);
 
         if (! class_exists($class)) {
             throw new UnknownCountryException('Unknown country: ' . $country);
         }
 
         return $this->formatters[$country] = new $class();
+    }
+
+    /**
+     * @param string $country
+     *
+     * @return string
+     */
+    private function getFormatterClass(string $country) : string
+    {
+        return __NAMESPACE__ . '\\Formatter\\' . strtoupper($country) . 'Formatter';
     }
 }

--- a/tests/PostcodeFormatterTest.php
+++ b/tests/PostcodeFormatterTest.php
@@ -40,6 +40,24 @@ class PostcodeFormatterTest extends TestCase
     }
 
     /**
+     * @return void
+     */
+    public function testFormatterIsNotSupportedCountry() : void
+    {
+        $formatter = new PostcodeFormatter();
+        $this->assertFalse($formatter->isSupportedCountry('UnknownCountry'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testFormatterIsSupportedCountry() : void
+    {
+        $formatter = new PostcodeFormatter();
+        $this->assertTrue($formatter->isSupportedCountry('FR'));
+    }
+
+    /**
      * @return array
      */
     public function providerFormatInvalidPostcode() : array


### PR DESCRIPTION
The goal of this PR is to:

- Increase visibility of getFormatter() so it can be used externally as to validate if a country is known even without postal_code.

- Add getFormatterClass() to filter by the supported countries of this plugin as:

```
$supportedCountries = array_filter($thirdPartyCountries, function (string $country) {
    return class_exist($postcodeFormatter->getFormatterClass($country));
})
```

No tests were added as no functionality was added and the new function is called by the existing code.