### PR TITLE
Improve IE formatter

### DIFF
--- a/src/Formatter/IEFormatter.php
+++ b/src/Formatter/IEFormatter.php
@@ -9,25 +9,32 @@ use Brick\Postcode\CountryPostcodeFormatter;
 /**
  * Validates and formats the postcodes in the Republic of Ireland.
  *
- * Postcodes can have eight different formats:
+ * Postcodes can have at least the following thirteen different formats:
  *
- * - ANN ANAN
- * - ANN AANN
+ * - ANN NNNA
+ * - ANN NANN
  * - ANN ANNN
+ * - ANN ANNA
+ * - ANN ANAN
  * - ANN ANAA
+ * - ANN AANN
+ * - ANN AANA
+ * - ANN AAAN
  *
- * - ANW ANAN
- * - ANW AANN
- * - ANW ANAA
- * - ANW ANNN (?) @todo ANNN is valid with ANN prefix, but not sure about ANW.
+ * - D6W ANAN
+ * - D6W AANN
+ * - D6W ANAA
+ * - D6W ANNN
  *
- * A stands for a capital letter, N stands for a digit, W is the letter W.
+ * A stands for the capital letter A,C,D,E,F,H,K,N,P,R,T,V,W,X or Y. N stands for a digit. D6W stans literally for D6W.
  *
- * @todo not all alphabet letters are allowed.
+ * The first part is one of the 139 Routing Keys, the second is a Unique Identifier.
+ * The pdf document linked below defines Eircode's character set on page 11.
  *
  * @see https://en.wikipedia.org/wiki/List_of_postal_codes
  * @see https://en.wikipedia.org/wiki/Postal_addresses_in_the_Republic_of_Ireland
- * @see https://www.eircode.ie/
+ * @see https://www.eircode.ie/docs/default-source/Common/prepareyourbusinessforeircode-edition3published.pdf
+ * @see https://www.autoaddress.ie/support/developer-centre/resources/routing-key-boundaries
  */
 class IEFormatter implements CountryPostcodeFormatter
 {
@@ -35,13 +42,14 @@ class IEFormatter implements CountryPostcodeFormatter
      * The regular expression pattern used to validate the postcode and extract the two parts.
      */
     private const PATTERN = '/^'
-    . '([A-Z][0-9][0-9W])'
     . '('
-    . '(?:[A-Z][0-9][0-9][0-9])|'
-    . '(?:[A-Z][0-9][A-Z][0-9])|'
-    . '(?:[A-Z][A-Z][0-9][0-9])|'
-    . '(?:[A-Z][0-9][A-Z][A-Z])'
+    . 'A41|A42|A45|A63|A67|A75|A81|A82|A83|A84|A85|A86|A91|A92|A94|A96|A98|C15|D01|D02|D03|D04|D05|D06|D6W|D07|D08|D09|'
+    . 'D10|D11|D12|D13|D14|D15|D16|D17|D18|D20|D22|D24|E21|E25|E32|E34|E41|E45|E53|E91|F12|F23|F26|F28|F31|F35|F42|F45|'
+    . 'F52|F56|F91|F92|F93|F94|H12|H14|H16|H18|H23|H53|H54|H62|H65|H71|H91|K32|K34|K36|K45|K56|K67|K78|N37|N39|N41|N91|'
+    . 'P12|P14|P17|P24|P25|P31|P32|P36|P43|P47|P51|P56|P61|P67|P72|P75|P81|P85|R14|R21|R32|R35|R42|R45|R51|R56|R93|R95|'
+    . 'T12|T23|T34|T45|T56|V14|V15|V23|V31|V35|V42|V92|V93|V94|V95|W12|W23|W34|W91|X35|X42|X91|Y14|Y21|Y25|Y34|Y35'
     . ')'
+    . '([ACDEFHKNPRTVWXY0-9]{4})'
     . '$/';
 
     /**

--- a/tests/Formatter/IEFormatterTest.php
+++ b/tests/Formatter/IEFormatterTest.php
@@ -45,14 +45,16 @@ class IEFormatterTest extends CountryPostcodeFormatterTest
             ['ABCDEF', null],
             ['ABCDEFGH', null],
 
-            ['A12B3C4', 'A12 B3C4'],
-            ['A12B3CD', 'A12 B3CD'],
-            ['A12BC34', 'A12 BC34'],
+            ['A98C7D6', 'A98 C7D6'],
+            ['A98C7DE', 'A98 C7DE'],
+            ['A98CD76', 'A98 CD76'],
             ['A98F625', 'A98 F625'],
+            ['T12X23H', 'T12 X23H'],
+            ['V94312N', 'V94 312N'],
 
-            ['A1WB3C4', 'A1W B3C4'],
-            ['A1WB3CD', 'A1W B3CD'],
-            ['A1WBC34', 'A1W BC34'],
+            ['D6WA1C2', 'D6W A1C2'],
+            ['D6WA1CD', 'D6W A1CD'],
+            ['D6WV593', 'D6W V593'],
 
             ['A1XB3C4', null],
             ['A1XB3CD', null],


### PR DESCRIPTION
There are only 139 Routing Keys, only D6W has to be handeled separately form ANN
ANW ANNN is D6W ANNN, add test case D6W V593.
Update documentation: add missing Unique Identifiers NNNA, NANN, ANNA, AANA and ANNN
Fix tests, because A12 is not a valid Routing Key by combining A[B]CD with 9876, (B is not allowed)