### PR TITLE
Add exception interface for easier catching without having to intimately know the library

### DIFF
--- a/src/InvalidPostcodeException.php
+++ b/src/InvalidPostcodeException.php
@@ -7,6 +7,6 @@ namespace Brick\Postcode;
 /**
  * Exception thrown when trying to format an invalid postcode.
  */
-class InvalidPostcodeException extends \Exception
+class InvalidPostcodeException extends \Exception implements PostcodeException
 {
 }

--- a/src/PostcodeException.php
+++ b/src/PostcodeException.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace Brick\Postcode;
+
+interface PostcodeException extends \Throwable
+{
+
+}

--- a/src/UnknownCountryException.php
+++ b/src/UnknownCountryException.php
@@ -7,6 +7,6 @@ namespace Brick\Postcode;
 /**
  * Exception thrown when an unknown country code is provided.
  */
-class UnknownCountryException extends \Exception
+class UnknownCountryException extends \Exception implements PostcodeException
 {
 }


### PR DESCRIPTION
Simple interface applied to all exceptions, allowing code such as:
```php
...
use Brick\Postcode\PostcodeException;

try {
    $postcodeFormatter->format('GB', $invalidPostcode);
} catch (PostcodeException $e) {
    throw new ApplicationSpecificException(
        sprintf('There was a problem with formatting the postcode "%s"', $invalidPostcode),
        0,
        $e
    );      
}
```