### PR TITLE
Formatter for IC (Canary Islands)

### DIFF
--- a/src/Formatter/ICFormatter.php
+++ b/src/Formatter/ICFormatter.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brick\Postcode\Formatter;
+
+use Brick\Postcode\CountryPostcodeFormatter;
+
+/**
+ * Validates and formats postcodes in Canary Islands (a subset of Spain).
+ *
+ * Postcodes consist of 5 digits, without separator,
+ * and start with 35 (Las Palmas) or 38 (Santa Cruz de Tenerife).
+ *
+ * @see https://www.iso.org/obp/ui/#iso:code:3166:IC
+ * @see https://en.wikipedia.org/wiki/List_of_postal_codes
+ * @see https://en.wikipedia.org/wiki/List_of_postal_codes_in_Spain
+ */
+class ICFormatter implements CountryPostcodeFormatter
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function format(string $postcode) : ?string
+    {
+        if (preg_match('/^(35|38)[0-9]{3}$/', $postcode) !== 1) {
+            return null;
+        }
+
+        return $postcode;
+    }
+}

--- a/tests/Formatter/ICFormatterTest.php
+++ b/tests/Formatter/ICFormatterTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Brick\Postcode\Tests\Formatter;
+
+use Brick\Postcode\CountryPostcodeFormatter;
+use Brick\Postcode\Formatter\ICFormatter;
+use Brick\Postcode\Tests\CountryPostcodeFormatterTest;
+
+/**
+ * Unit tests for the IC postcode formatter.
+ */
+class ICFormatterTest extends CountryPostcodeFormatterTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getFormatter() : CountryPostcodeFormatter
+    {
+        return new ICFormatter();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function providerFormat() : array
+    {
+        return [
+            ['', null],
+
+            ['1', null],
+            ['12', null],
+            ['123', null],
+            ['1234', null],
+            ['12345', null],
+            ['123456', null],
+            ['34567', null],
+            ['345678', null],
+            ['35123', '35123'],
+            ['351234', null],
+            ['38123', '38123'],
+            ['381234', null],
+
+            ['A', null],
+            ['AB', null],
+            ['ABC', null],
+            ['ABCD', null],
+            ['ABCDE', null],
+            ['ABCDEF', null],
+        ];
+    }
+}


### PR DESCRIPTION
Hi,

This PR adds the formatter for [ISO 3166: IC](https://www.iso.org/obp/ui/#iso:code:3166:IC) (Canary Islands). 
