### PR TITLE
Support for 7-digit postal codes in Egypt

### DIFF
--- a/src/Formatter/EGFormatter.php
+++ b/src/Formatter/EGFormatter.php
@@ -9,10 +9,11 @@ use Brick\Postcode\CountryPostcodeFormatter;
 /**
  * Validates and formats postcodes in Egypt.
  *
- * Postcodes consist of 5 digits, without separator.
+ * Postcodes consist of 5 or 7 digits, without separator.
  *
  * @see https://en.wikipedia.org/wiki/List_of_postal_codes
  * @see https://en.wikipedia.org/wiki/List_of_postal_codes_in_Egypt
+ * @see https://www.upu.int/UPU/media/upu/PostalEntitiesFiles/addressingUnit/egyEn.pdf
  */
 class EGFormatter implements CountryPostcodeFormatter
 {

--- a/src/Formatter/EGFormatter.php
+++ b/src/Formatter/EGFormatter.php
@@ -21,7 +21,7 @@ class EGFormatter implements CountryPostcodeFormatter
      */
     public function format(string $postcode) : ?string
     {
-        if (preg_match('/^[0-9]{5}$/', $postcode) !== 1) {
+        if (preg_match('/^\d{5}(\d{2})?$/', $postcode) !== 1) {
             return null;
         }
 


### PR DESCRIPTION
The new Egypt Postal code system depends on assigning 7 digit postal code number to every block of buildings, which assure better accuracy of identifying the postal code.

https://epostalmap.com/en/