### PR TITLE
Fix: Validate Austrian post codes to exclude invalid values starting with 0

### DIFF
--- a/src/Formatter/ATFormatter.php
+++ b/src/Formatter/ATFormatter.php
@@ -21,7 +21,7 @@ class ATFormatter implements CountryPostcodeFormatter
      */
     public function format(string $postcode) : ?string
     {
-        if (preg_match('/^[0-9]{4}$/', $postcode) !== 1) {
+        if (preg_match('/^[1-9][0-9]{3}$/', $postcode) !== 1) {
             return null;
         }
 

--- a/src/Formatter/ATFormatter.php
+++ b/src/Formatter/ATFormatter.php
@@ -9,7 +9,7 @@ use Brick\Postcode\CountryPostcodeFormatter;
 /**
  * Validates and formats postcodes in Austria.
  *
- * Postcodes consist of 4 digits, without separator.
+ * Postcodes consist of 4 digits, without separator. The first digit must be 1-9.
  *
  * @see https://en.wikipedia.org/wiki/List_of_postal_codes
  * @see https://en.wikipedia.org/wiki/Postal_codes_in_Austria


### PR DESCRIPTION
Previously, postal codes such as '0000' or '0999' were considered valid, but in reality, Austrian postal codes always start with digits from 1 to 9. This update corrects the validation to ensure compliance with the Austrian postal code system 
(see: https://en.wikipedia.org/wiki/Postal_codes_in_Austria#System).