### PR TITLE
Testing with global formatter

### DIFF
--- a/tests/CountryPostcodeFormatterTest.php
+++ b/tests/CountryPostcodeFormatterTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Brick\Postcode\Tests;
 
 use Brick\Postcode\CountryPostcodeFormatter;
+use Brick\Postcode\InvalidPostcodeException;
+use Brick\Postcode\PostcodeFormatter;
+use Brick\Postcode\UnknownCountryException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -22,7 +25,23 @@ abstract class CountryPostcodeFormatterTest extends TestCase
      */
     public function testFormat(string $input, ?string $expectedOutput) : void
     {
-        $this->assertSame($expectedOutput, $this->getFormatter()->format($input));
+        $formatter = new PostcodeFormatter();
+        try {
+            $result = $formatter->format($this->getCountry(), $input);
+        } catch (InvalidPostcodeException $e) {
+            $result = null;
+        }
+        $this->assertSame($expectedOutput, $result);
+    }
+
+    /**
+     * Returns the test associated Country ISO2 code
+     *
+     * @return string
+     */
+    public function getCountry() : string
+    {
+        return substr((new \ReflectionClass($this))->getShortName(), 0, 2);
     }
 
     /**

--- a/tests/Formatter/BEFormatterTest.php
+++ b/tests/Formatter/BEFormatterTest.php
@@ -37,8 +37,8 @@ class BEFormatterTest extends CountryPostcodeFormatterTest
             ['ABCDE', null],
             ['ABCDEF', null],
 
-            ['B8084', '8084'],
-            ['X8084', null],
+            ['B-8084', '8084'],
+            ['X-8084', null],
         ];
     }
 }


### PR DESCRIPTION
Hi Ben, as discussed in the previous [PR 13](https://github.com/brick/postcode/pull/13#discussion_r1775012796), i hereby present a new PR to make testing use the global postcode formatter.

A few things to note:

1.  Because this is a proof of concept commit, for readability i only changed the BE formatter test. Others will follow later of course if necessary.
2.  This PR makes al the `getFormatter` functions in the tests and abstract test class obsolete but they have not yet been removed.
3. This PR introduces the new `getCountry` function in the abstract test class using reflection because according to my research this is the easiest and fastest way. However i know that your not a fan of this which is why i am open to suggestions. It was also a fast way of showing you in this PR what i am trying to accomplish. Reflection does however reassure that the formatter has to bo named exactly in the same way as the test and if not, it will all fail.
4.  I again want to stretch that this ensures that the test actually tests the actual output and format a user will see when using the public API of this package. Especially when a stripe or space is part of the format and future changes may interfere.

@BenMorel Looking forward to your viewings on this.
